### PR TITLE
Initial material update fix

### DIFF
--- a/QuickOutline/Scripts/Outline.cs
+++ b/QuickOutline/Scripts/Outline.cs
@@ -96,7 +96,7 @@ public class Outline : MonoBehaviour {
     LoadSmoothNormals();
 
     // Apply material properties immediately
-    needsUpdate = true;
+    UpdateMaterialProperties();
   }
 
   void OnEnable() {


### PR DESCRIPTION
Material properties are not applied instantly as the comment suggests. This leads to a behavior where, in the first frame, the outline appears as the default white color, and then it is corrected in the second frame.