### PR TITLE
fix outline gaps for SkinnedMeshRenderer by smoothing normals

### DIFF
--- a/QuickOutline/Scripts/Outline.cs
+++ b/QuickOutline/Scripts/Outline.cs
@@ -210,8 +210,8 @@ public class Outline : MonoBehaviour {
         continue;
       }
 
-      // Clear UV3
-      skinnedMeshRenderer.sharedMesh.uv4 = new Vector2[skinnedMeshRenderer.sharedMesh.vertexCount];
+      var smoothNormals = SmoothNormals(skinnedMeshRenderer.sharedMesh);
+      skinnedMeshRenderer.sharedMesh.SetUVs(3, smoothNormals);
 
       // Combine submeshes
       CombineSubmeshes(skinnedMeshRenderer.sharedMesh, skinnedMeshRenderer.sharedMaterials);


### PR DESCRIPTION
Fixing an issue similar to the one already described in https://github.com/chrisnolet/QuickOutline/issues/24
The issue only seems to come up in the combination of SkinnedMeshRenderer + low-poly/hard normals. But I also tested that the fix has no adverse effects on meshes with smooth normals by changing the import settings of my test mesh to calculate normals and set smoothing angle to its highest possible value 180.

Before:
![image](https://github.com/chrisnolet/QuickOutline/assets/41569108/5585f548-607d-40cf-92d1-4285bc5657bd)

After:
![image](https://github.com/chrisnolet/QuickOutline/assets/41569108/6c9b9d8a-171c-41a8-ae89-7bdddec99db2)