### PR TITLE
add sorting layer to deal with overlapping meshes

### DIFF
--- a/QuickOutline/Resources/Shaders/OutlineFill.shader
+++ b/QuickOutline/Resources/Shaders/OutlineFill.shader
@@ -11,7 +11,8 @@ Shader "Custom/Outline Fill" {
     [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("ZTest", Float) = 0
 
     _OutlineColor("Outline Color", Color) = (1, 1, 1, 1)
-    _OutlineWidth("Outline Width", Range(0, 10)) = 2
+    _OutlineWidth("Outline Width", Range(0, 10)) = 2    
+    _ZRef("ZRef", Float) = 1
   }
 
   SubShader {
@@ -30,7 +31,7 @@ Shader "Custom/Outline Fill" {
       ColorMask RGB
 
       Stencil {
-        Ref 1
+        Ref [_ZRef]
         Comp NotEqual
       }
 

--- a/QuickOutline/Resources/Shaders/OutlineMask.shader
+++ b/QuickOutline/Resources/Shaders/OutlineMask.shader
@@ -8,7 +8,8 @@
 
 Shader "Custom/Outline Mask" {
   Properties {
-    [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("ZTest", Float) = 0
+    [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("ZTest", Float) = 0    
+    _ZRef("ZRef", Float) = 1
   }
 
   SubShader {
@@ -24,8 +25,8 @@ Shader "Custom/Outline Mask" {
       ZWrite Off
       ColorMask 0
 
-      Stencil {
-        Ref 1
+      Stencil {        
+        Ref [_ZRef]
         Pass Replace
       }
     }

--- a/QuickOutline/Scripts/Outline.cs
+++ b/QuickOutline/Scripts/Outline.cs
@@ -48,6 +48,16 @@ public class Outline : MonoBehaviour {
     }
   }
 
+  public int SortingLayer
+  {
+    get { return sortingLayer; }
+    set
+    {
+      sortingLayer = value;
+      needsUpdate = true;
+    }
+  }
+
   [Serializable]
   private class ListVector3 {
     public List<Vector3> data;
@@ -61,6 +71,9 @@ public class Outline : MonoBehaviour {
 
   [SerializeField, Range(0f, 10f)]
   private float outlineWidth = 2f;
+
+  [SerializeField]
+  private int sortingLayer;
 
   [Header("Optional")]
 
@@ -273,6 +286,12 @@ public class Outline : MonoBehaviour {
 
     // Apply properties according to mode
     outlineFillMaterial.SetColor("_OutlineColor", outlineColor);
+
+    outlineFillMaterial.SetFloat("_ZRef", sortingLayer + 1);
+    outlineMaskMaterial.SetFloat("_ZRef", sortingLayer + 1);
+
+    outlineMaskMaterial.renderQueue = 3100 + 20 * sortingLayer;
+    outlineFillMaterial.renderQueue = 3110 + 20 * sortingLayer;
 
     switch (outlineMode) {
       case Mode.OutlineAll:


### PR DESCRIPTION
Based on this post in a [unity forum thread](https://discussions.unity.com/t/stop-outlines-from-merging-when-overlapping-urp/882363/6), and a fix for issue #39 

It adds a sorting layer integer to the Outline class to change the render queue index, and the stencil ref index of both shaders. This allows outlined objects to overlap and have separate outlines, where higher sorting layers or visible in front of lower sorting layers.